### PR TITLE
Fix test conflicts and improve setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,14 +264,20 @@ We welcome contributions to the Receipt OCR Engine! To contribute, please follow
 
     # Install development and test dependencies
     uv sync --all-extras --dev
-    uv pip install -r src/tesseract_ocr/requirements.txt
     uv pip install -e.
+    
+    # Optional: Install requirements for the tesseract_ocr module
+    uv pip install -r src/tesseract_ocr/requirements.txt
     ```
 
 4.  **Make your changes** and ensure they adhere to the project's coding style.
 5.  **Run tests** to ensure your changes haven't introduced any regressions:
     ```bash
-    uv run pytest
+    # Run tests for the receipt_ocr module
+    uv run pytest tests/receipt_ocr
+    
+    # Run tests for the tesseract_ocr module  
+    uv run pytest tests/tesseract_ocr
     ```
 6.  **Run linting and formatting checks**:
     ```bash


### PR DESCRIPTION
## What does this PR do?

Fixes pytest collection issues caused by duplicate `test_utils.py` files and improves development setup clarity.

**Related Issue:**

Fixes #22

**Additional Notes:**


## Changes
- **Test Instructions**: Updated contributing guide to run tests separately for each module (`tests/receipt_ocr` and `tests/tesseract_ocr`) instead of running all tests together, avoiding import conflicts from duplicate test file names
- **Setup Instructions**: Made tesseract requirements installation optional and clearly labeled as being specific to the tesseract_ocr module

## Problem Solved
Previously, running `uv run pytest` would fail with "import file mismatch" error due to both modules having `test_utils.py` files. Now contributors can run tests without conflicts while having clear optional setup steps.

## Testing
- Verified tests run successfully when executed separately
- Confirmed README changes are clear and accurate
